### PR TITLE
Add script for bincompat setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,3 +324,124 @@ Pass required commands to script:
    ```
 
    The image prints the `Hello, world!` message.
+
+## Binary Compatibility
+
+Use the `do-unikraft-bincompat` to set up, build and run [`app-elfloader`](github.com/unikraft/app-elfloader) and other support repositories with Unikraft.
+Run the script anywhere.
+It will create a conventional local file hierarchy for building the Unikraft image.
+Repositories will be moved to the corresponding branch.
+
+Pass required commands to script:
+
+1. First, set up repositories:
+
+   ```
+   $ ./do-unikraft-bincompat setup
+   ```
+
+   This results in creating the `unikraft-bincompat/` folder with the file hierarchy:
+
+   ```
+   $ tree -L 2 unikraft-bincompat/
+   unikraft-bincompat/
+   |-- apps
+   |   |-- app-elfloader
+   |   |-- run-app-elfloader
+   |   `-- static-pie-apps
+   |-- libs
+   |   |-- libelf
+   |   |-- lwip
+   |   `-- zydis
+   `-- unikraft
+       |-- arch
+       |-- CODING_STYLE.md
+       |-- Config.uk
+       |-- CONTRIBUTING.md
+       |-- COPYING.md
+       |-- doc
+       |-- include
+       |-- lib
+       |-- Makefile
+       |-- Makefile.uk
+       |-- plat
+       |-- README.md
+       |-- support
+       `-- version.mk
+   ```
+
+1. Run the `helloworld` static PIE in Unikraft using the prebuilt `app-elfloader` Unikraft image:
+
+   ```
+   $ ./do-unikraft-bincompat run
+   Powered by
+   o.   .o       _ _               __ _
+   Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
+   oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
+   oOo oOO| | | | |   (| | | (_) |  _) :_
+    OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
+               Mimas 0.7.0~1e17a9c8-custom
+   Hello, World!
+   ```
+
+1. Build the `app-elfloader` Unikraft image:
+
+   ```
+   $ ./do-unikraft-bincompat build
+     [...]
+     LD      app-elfloader_kvm-x86_64.ld.o
+     OBJCOPY app-elfloader_kvm-x86_64.o
+     LD      app-elfloader_kvm-x86_64.dbg
+     SCSTRIP app-elfloader_kvm-x86_64
+     GZ      app-elfloader_kvm-x86_64.gz
+   ```
+
+1. Run the `helloworld` static PIE in Unikraft using the newly built `app-elfloader` Unikraft image:
+
+   ```
+   $ ./do-unikraft-bincompat run_build
+   Powered by
+   o.   .o       _ _               __ _
+   Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
+   oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
+   oOo oOO| | | | |   (| | | (_) |  _) :_
+    OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
+                       Mimas 0.7.0~bbb00c7
+   Hello, World!
+   ```
+
+1. Clean the built image:
+
+   ```
+   $ ./do-unikraft-bincompat clean
+     [...]
+     RM      build/
+     RM      config
+     [...]
+   ```
+
+1. Build the `app-elfloader` Unikraft debug image:
+
+   ```
+   $ ./do-unikraft-bincompat build_debug
+     [...]
+
+     LD      app-elfloader_kvm-x86_64.ld.o
+     OBJCOPY app-elfloader_kvm-x86_64.o
+     LD      app-elfloader_kvm-x86_64.dbg
+     SCSTRIP app-elfloader_kvm-x86_64
+     GZ      app-elfloader_kvm-x86_64.gz
+     LN      app-elfloader_kvm-x86_64.dbg.gdb.py
+     [...]
+   ```
+
+1. Run the `helloworld` static PIE in Unikraft using the newly built `app-elfloader` Unikraft debug image:
+
+   ```
+   $ ./do-unikraft-bincompat run_build_debug
+   [...]
+   [    0.410842] dbg:  [libvfscore] <main.c @  703> (ssize_t) uk_syscall_r_writev((int) 0x1, (const struct iovec *) 0x3ff8f8d8, (int) 0x1)
+   Hello, World!
+   [    0.413533] dbg:  [libsyscall_shim] <uk_syscall_binary.c @   76> Binary system call request "exit_group" (231) at ip:0x3fe51156 (arg0=0x0, arg1=0x3c, ...)
+   [...]
+   ```

--- a/do-unikraft-bincompat
+++ b/do-unikraft-bincompat
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+top=unikraft-bincompat
+libs="$top"/libs
+apps="$top"/apps
+uk="$top"/unikraft
+app="$apps"/app-elfloader
+
+setup()
+{
+    mkdir -p "$top"
+    mkdir -p "$libs"
+    mkdir -p "$apps"
+
+    git clone https://github.com/unikraft/unikraft "$uk"
+
+    pushd "$uk" > /dev/null
+    git remote add razvand-bincompat https://github.com/razvand/unikraft-bincompat
+    git fetch razvand-bincompat
+    git checkout -b bin-compat razvand-bincompat/bin-compat
+    popd > /dev/null
+
+    git clone https://github.com/unikraft/app-elfloader "$app"
+
+    pushd "$app" > /dev/null
+    git checkout -b lyon-hackathon origin/lyon-hackathon
+    popd > /dev/null
+
+    git clone https://github.com/unikraft/lib-libelf "$libs"/libelf
+    git clone https://github.com/unikraft/lib-zydis "$libs"/zydis
+    git clone https://github.com/unikraft/lib-lwip "$libs"/lwip
+
+    pushd "$libs"/lwip > /dev/null
+    git remote add razvand https://github.com/razvand/lib-lwip
+    git fetch razvand
+    git checkout -b lyon-hackathon razvand/lyon-hackathon
+    popd > /dev/null
+
+    git clone https://github.com/unikraft/run-app-elfloader "$apps"/run-app-elfloader
+    git clone https://github.com/unikraft/static-pie-apps "$apps"/static-pie-apps
+}
+
+build()
+{
+    pushd "$app" > /dev/null
+    cp config/config .config
+    make
+    popd > /dev/null
+}
+
+build_debug()
+{
+    pushd "$app" > /dev/null
+    cp config/config_debug .config
+    make
+    popd > /dev/null
+}
+
+clean()
+{
+    pushd "$app" > /dev/null
+    export UK_WORKDIR=$(pwd)/../../
+    make distclean
+    popd > /dev/null
+}
+
+remove()
+{
+    rm -fr "$top"
+}
+
+_setup_networking()
+{
+    sudo ip link set dev virbr0 down
+    sudo ip link del dev virbr0
+    sudo ip link add virbr0 type bridge
+    sudo ip address add 172.44.0.1/24 dev virbr0
+    sudo ip link set dev virbr0 up
+}
+
+run_helloworld()
+{
+    pushd "$apps"/run-app-elfloader > /dev/null
+    ./run_elfloader ../static-pie-apps/lang/c/helloworld
+    popd > /dev/null
+}
+
+run_helloworld_build()
+{
+    pushd "$apps"/run-app-elfloader > /dev/null
+    ./run_elfloader -k ../app-elfloader/build/app-elfloader_kvm-x86_64 ../static-pie-apps/lang/c/helloworld
+    popd > /dev/null
+}
+
+run_helloworld_build_debug()
+{
+    pushd "$apps"/run-app-elfloader > /dev/null
+    ./run_elfloader -k ../app-elfloader/build/app-elfloader_kvm-x86_64.dbg ../static-pie-apps/lang/c/helloworld
+    popd > /dev/null
+}
+
+if test $# -ne 1; then
+    echo "Usage: $0 <command>" 1>&2
+    echo "  command: setup build build_debug clean run run_build run_build_debug remove" 1>&2
+    exit 1
+fi
+
+command="$1"
+
+case "$command" in
+
+    "setup")
+        setup
+        ;;
+
+    "build")
+        build
+        ;;
+
+    "build_debug")
+        build_debug
+        ;;
+
+    "clean")
+        clean
+        ;;
+
+    "run")
+        run_helloworld
+        ;;
+
+    "run_build")
+        run_helloworld_build_debug
+        ;;
+
+    "run_build_debug")
+        run_helloworld_build_debug
+        ;;
+
+    "remove")
+        remove
+        ;;
+
+    *)
+        echo "Unknown command"
+        exit 1
+esac


### PR DESCRIPTION
The script (`do-unikraft-bincompat`) creates a local conventional setup with `app-elfloader`, unikraft and required libraries. It places them on the required branches to work.

The support repositories (`run-app-elfloader`, `static-pie-apps`) are cloned and used.