### PR TITLE
musl: Add script for testing app-micropython

### DIFF
--- a/include/common_functions
+++ b/include/common_functions
@@ -429,6 +429,10 @@ setup()
         setup_nginx
         popd > /dev/null
     fi
+
+    if test ! -d "$libs"/micropython; then
+        git clone https://github.com/unikraft/lib-micropython "$libs"/micropython
+    fi
 }
 
 build()

--- a/musl/README.md
+++ b/musl/README.md
@@ -136,6 +136,31 @@ A confirmation message is also shown by the Unikraft server in its console:
 Sent a reply
 ```
 
+## app-micropython
+
+Use the `do-micropython` script to build and run [`app-micropython`](https://github.com/unikraft/app-micropython.git) with Unikraft and [Musl](https://github.com/unikraft/lib-musl) as its libc.
+Follow the exact same steps as above, but replace `helloworld` with `micropython` throughout commands to use.
+
+The `run` command runs the `helloworld.py` script in a MicroPython runtime.
+
+```
+./do-micropython run
+
+[...]
+SeaBIOS (version 1.10.2-1ubuntu1)
+Booting from ROM...
+Powered by
+o.   .o       _ _               __ _
+Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
+oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
+oOo oOO| | | | |   (| | | (_) |  _) :_
+ OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
+                 Phoebe 0.10.0~4eba7029
+/home/razvan/Documents/Unikraft/test_musl/workdir/apps/app-micropython/build/micropython_kvm-x86_64: can't open file 'console=ttyS0': [Errno 20] Not a directory
+Hello, world!
+Console terminated, terminating guest (PID: 11461)...
+```
+
 ## test
 
 Use the `do-test` script to build and run the custom tests from [Dragoș's repository](https://github.com/dragosargint/test);

--- a/musl/do-micropython
+++ b/musl/do-micropython
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# https://stackoverflow.com/a/246128/4804196
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+    SOURCE=$(readlink "$SOURCE")
+    [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+source "$SCRIPT_DIR"/../include/base
+
+app="$top"/apps/app-micropython
+
+source "$SCRIPT_DIR"/../include/common_functions
+
+USE_LWIP=1
+
+setup_app()
+{
+    git clone https://github.com/unikraft/app-micropython "$app"
+
+    pushd "$app" > /dev/null
+
+    # Use updated kraft.yaml (including Musl dependency).
+    git remote add upb https://github.com/unikraft-upb/app-micropython
+    git fetch upb
+    git checkout -b use-musl upb/use-musl
+
+    popd > /dev/null
+}
+
+run()
+{
+    pushd "$app" > /dev/null
+    export UK_WORKDIR=$(pwd)/../../
+    kraft run -M 1024 -i "helloworld.py"
+    popd > /dev/null
+}
+
+run_qemu()
+{
+    #_setup_networking
+    pushd "$app" > /dev/null
+    sudo qemu-system-x86_64 \
+        -initrd "helloworld.py" \
+        -kernel "build/micropython_kvm-x86_64" \
+        -cpu host \
+        -enable-kvm \
+        -nographic
+    popd > /dev/null
+}
+
+source "$SCRIPT_DIR"/../include/common_command


### PR DESCRIPTION
This PR adds a script for automate testing of app-micropython with musl as a dependency.
It also completes the `common functions` with the `lib-micropython` setup.
Please note that, for the moment, we need to remove [this line](https://github.com/unikraft/lib-micropython/blob/staging/Config.uk#L9) from `lib-micropython`. This will be fix once we will have `uksignal` integration with musl.

Signed-off-by: Razvan Virtan <virtanrazvan@gmail.com>