### PR TITLE
Add PR#24 when building musl

### DIFF
--- a/include/common_functions
+++ b/include/common_functions
@@ -117,6 +117,10 @@ setup_musl()
     git checkout -b add-sysexits.h upb/add-sysexits.h
     git checkout -b add-wait.c upb/add-wait.c
 
+    git remote add Fpostolache https://github.com/maniatro111/lib-musl.git
+    git fetch Fpostolache
+    git checkout -b include-tgmath-header-when-math-and-complex-libs-are-enabled Fpostolache/include-tgmath-header-when-math-and-complex-libs-are-enabled
+
     # Rebase all branches
     git checkout -b musl-support staging
     git rebase thread_support
@@ -140,6 +144,7 @@ setup_musl()
     git cherry-pick posix-user-sources
     git cherry-pick add-sysexits.h
     git cherry-pick add-wait.c
+    git cherry-pick include-tgmath-header-when-math-and-complex-libs-are-enabled
 }
 
 setup_lwip()


### PR DESCRIPTION
This PR adds to the `common functions` file in the `musl` setup by adding one last commit that includes `tgmath.h` when musl builds.
Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>