### PR TITLE
make-based: Enhance common scripts

### DIFF
--- a/make-based/include/common_command
+++ b/make-based/include/common_command
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-if test $# -ne 1; then
+usage()
+{
     echo "Usage: $0 <command>" 1>&2
     echo "  command: setup configure build clean run run_debug remove" 1>&2
+}
+
+if test $# -ne 1; then
+    usage
     exit 1
 fi
 
@@ -40,6 +45,7 @@ case "$command" in
         ;;
 
     *)
-        echo "Unknown command"
+        echo "Unknown command: $command"
+        usage
         exit 1
 esac

--- a/make-based/include/common_functions
+++ b/make-based/include/common_functions
@@ -100,7 +100,7 @@ install_lib()
     if test ! -d "$libs"/"$l"; then
         git clone https://github.com/unikraft/lib-"$l" "$libs"/"$l"
         pushd "$libs"/"$l" > /dev/null
-        if test $(type -t setup_"$l") == "function"; then
+        if test "$(type -t setup_"$l")" = "function"; then
             setup_"$l"
         fi
         popd > /dev/null


### PR DESCRIPTION
This fixes the equality test in the `install_lib` common function. In addition, it displays the usage message when and unknown command is specified to `do.sh`.

Hackathon team name: `ByteBusters`