### PR TITLE
include: Reset kraft.yaml before running kraft

### DIFF
--- a/include/common_functions
+++ b/include/common_functions
@@ -215,8 +215,11 @@ build()
     fi
     pushd "$app" > /dev/null
     export UK_WORKDIR=$(pwd)/../../
+    git checkout -- kraft.yaml
     kraft configure -F -m x86_64 -p kvm
+    git checkout -- kraft.yaml
     kraft prepare
+    git checkout -- kraft.yaml
     kraft build -j $(nproc)
     popd > /dev/null
 }


### PR DESCRIPTION
Running `kraft` may update the `kraft.yaml` file. So, before each `kraft` command (`configure`, `prepare`, `build`), reset the `kraft.yaml` file using `git checkout --`.