### PR TITLE
StefanJum/add testing scripts

### DIFF
--- a/make-based/build-all.sh
+++ b/make-based/build-all.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# https://stackoverflow.com/a/246128/4804196
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+    SOURCE=$(readlink "$SOURCE")
+    [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPT_DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+top=$(pwd)/../workdir
+libs=$(pwd)/../workdir/libs
+uk=$(pwd)/../workdir/unikraft
+
+source "$SCRIPT_DIR"/../include/common_functions
+
+if test $# -lt 1; then
+    echo -e "Usage: $0 <PR-number | branch> [deps]\n" 1>&2
+    echo "The dependencies are PRs from the unikraft core or external libraries repositories." 1>&2
+    echo -e "\ne.g. $0 123 musl/10 unikraft/20 lwip/15" 1>&2
+    echo "will pull PRs 123 and 20 from the unikraft core, PR 10 from lib-musl and PR 20 form lwip."
+    echo -e "\n$0 staging musl/10 unikraft/20 lwip/15" 1>&2
+    echo "will pull PR 20 from the unikraft core, PR 10 from lib-musl and PR 20 form lwip."
+    exit 1
+fi
+
+log_file=$(pwd)/logs/err.log
+PR_number="$1"
+
+unset UK_ROOT UK_WORKDIR UK_LIBS
+mkdir "$(pwd)/logs" 2> /dev/null
+
+setup
+
+pushd "$uk" > /dev/null || exit 1
+
+git checkout staging
+git branch -D setup 2> /dev/null
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+    git fetch origin "pull/$PR_number/head":setup || exit 1
+    git checkout setup
+    git rebase staging || exit 1
+else
+    git fetch origin "$1":setup || exit 1
+    git checkout setup
+fi
+
+popd > /dev/null || exit 1
+
+shift 1
+for dep in "$@"; do
+    lib=$(echo "$dep" | cut -d'/' -f1)
+    pr=$(echo "$dep" | cut -d'/' -f2)
+
+    if test "$lib" = "unikraft"; then
+        pushd "$uk" > /dev/null || exit 1
+    else
+        pushd "$libs/$lib" > /dev/null || exit 1
+    fi
+
+    # PRs that are given in the list will be stashed on top of each other
+    # beware of eventual conflicts that may appear
+    git checkout setup > /dev/null 2>&1 || git checkout -b setup > /dev/null 2>&1
+    git fetch origin "pull/$pr/head":"pr-$pr"
+    git rebase "pr-$pr" || exit 1
+
+    popd > /dev/null || exit 1
+done
+
+while read -r script; do
+    pushd "$script" > /dev/null || exit 1
+
+    app=$(echo "$script" | cut -d'-' -f2-)
+
+    # FIXME: Change this after the PRs needed for binray compatibility
+    # are all merged
+    # Skip the elfloader since the custom setup will mess up our setup.
+    if [[ "$app" = "elfloader" ]]; then
+        popd > /dev/null || exit 1
+        continue
+    fi
+
+    echo -n "Building $app using 'clang'... "
+    /bin/bash "do.sh" clean > /dev/null 2>&1
+    /bin/bash "do.sh" setup > /dev/null 2>&1
+    yes "" | /bin/bash "do.sh" build_clang 1> /dev/null 2> "$log_file.$app.clang" && echo "PASSED" || echo "FAILED"
+
+    echo -n "Building $app using 'gcc'... "
+    /bin/bash "do.sh" clean > /dev/null 2>&1
+    /bin/bash "do.sh" setup > /dev/null 2>&1
+    yes "" | /bin/bash "do.sh" build 1> /dev/null 2> "$log_file.$app.gcc" && echo "PASSED" || echo "FAILED"
+
+    popd > /dev/null || exit 1
+done <<< "$(find . -type d -name "app*")"


### PR DESCRIPTION
The `./build_all.sh` script will test the build for all the applications that
have scripts created in the `make-based/` directory, with certain PRs
and dependencies pulled.

To use it, run `./build_all.sh <PR number | branch> [deps]`.
The `PR number` is the number of the unikraft core pull request you want
to test. The `branch` argument is the unikraft core branch you want to
add the dependencies on top of (likely `staging` or `stable`).

The `deps` argument is a list of dependencies, in form of pull requests,
from the unikraft core or external libraries repositories.
For example, `./build_all.sh 123 musl/10 lwip/20 unikraft/200` will pull
PR 123 from the unikraft core, rebase it on top of PR 200 and add the
wanted PRs to the external libraries `musl` and `lwip`.

The results of the script will be shown as below, and the errors will be
saved in log files `err.log.<app-name>`:
```
Building nginx... FAILED
Building elfloader... PASSED
Building helloworld... PASSED
Building httpreply... PASSED
```

Needs #44 to be merged first.