### PR TITLE
make-based: Add support for extra application arguments

### DIFF
--- a/make-based/include/do_base
+++ b/make-based/include/do_base
@@ -49,6 +49,8 @@ arguments="-m $memory -nographic -nodefaults "
 arguments+="-display none -serial stdio -device isa-debug-exit "
 arguments+="-kernel $kvm_image "
 
+app_arguments=""
+
 if test ! -z "$use_9p_rootfs"; then
     if test "$use_9p_rootfs" -eq 1; then
         arguments+="-fsdev local,security_model=passthrough,id=hvirtio0,path=$rootfs_9p "
@@ -69,8 +71,12 @@ if test ! -z "$use_networking"; then
         _setup_networking
         arguments+="-netdev bridge,id=en0,br=virbr0 "
         arguments+="-device virtio-net-pci,netdev=en0 "
-        arguments+="-append \"netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 --\" "
+        app_arguments+="netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 -- "
     fi
+fi
+
+if test ! -z "$extra_app_arguments"; then
+	app_arguments+="$extra_app_arguments"
 fi
 
 run()
@@ -80,7 +86,7 @@ run()
         exit 1
     fi
     pushd "$app" > /dev/null
-    eval sudo qemu-system-x86_64 "$arguments"
+    eval sudo qemu-system-x86_64 "$arguments" -append "\"$app_arguments\""
     popd > /dev/null
 }
 
@@ -91,7 +97,7 @@ run_debug()
         exit 1
     fi
     pushd "$app" > /dev/null
-    eval sudo qemu-system-x86_64 "$arguments" -gdb tcp::1234 -S
+    eval sudo qemu-system-x86_64 "$arguments" -gdb tcp::1234 -S -append "\"$app_arguments\""
     popd > /dev/null
 }
 


### PR DESCRIPTION
Some applications require extra arguments to be passed to the kernel by using the `-append` option from `qemu-system`. This commits allows addition of extra application arguments by using the `$extra_app_arguments` variable in the application `do.sh` script.

This will be used, for example, when running `app-redis`, to pass the `redis.conf` file to it. (`$extra_app_arguments="/redis.conf"`)