### PR TITLE
make-based: Change kernel image naming

### DIFF
--- a/make-based/include/do_base
+++ b/make-based/include/do_base
@@ -43,7 +43,7 @@ setup_app()
     fi
 }
 
-kvm_image=build/"$app_basename"_kvm-x86_64
+kvm_image=build/"$app_basename"_qemu-x86_64
 
 if test -z "$memory"; then
     memory="256M"


### PR DESCRIPTION
Since firecracker support was added, the image naming changed from `app-kvm_arch` to `app-qemu_arch`.