### PR TITLE
make-based: Add compiler to elfloader build command

### DIFF
--- a/make-based/app-elfloader/do.sh
+++ b/make-based/app-elfloader/do.sh
@@ -276,6 +276,7 @@ case "$command" in
         ;;
 
     "build")
+        cc=gcc
         build
         ;;
 


### PR DESCRIPTION
The build command requires a `cc` variable to be set, that specifies the compiler that will be used. Since the elfloader does not use the `include/common_command` do define commands, we need to do this in the `do.sh` file.