### PR TITLE
make-based: Add reset-to-release-tag feature

### DIFF
--- a/make-based/include/base
+++ b/make-based/include/base
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+release_tag="RELEASE-0.13.1"
 top=../../workdir
 libs="$top"/libs
 apps="$top"/apps

--- a/make-based/include/common_functions
+++ b/make-based/include/common_functions
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+reset_to_release_branch()
+{
+    git reset --hard HEAD
+    git checkout staging
+    git branch -D br-"$release_tag"
+    git checkout -b br-"$release_tag" "$release_tag"
+}
+
 setup_base()
 {
     mkdir -p "$top"
@@ -9,7 +17,9 @@ setup_base()
     if test ! -d "$uk"; then
         git clone https://github.com/unikraft/unikraft "$uk"
     fi
+
     pushd "$uk" > /dev/null
+    reset_to_release_branch
     if test "$(type -t setup_unikraft)" = "function"; then
         setup_unikraft
     fi
@@ -22,7 +32,9 @@ install_lib()
     if test ! -d "$libs"/"$l"; then
         git clone https://github.com/unikraft/lib-"$l" "$libs"/"$l"
     fi
+
     pushd "$libs"/"$l" > /dev/null
+    reset_to_release_branch
     if test "$(type -t setup_"$l")" = "function"; then
         setup_"$l"
     fi

--- a/make-based/include/do_base
+++ b/make-based/include/do_base
@@ -26,7 +26,7 @@ setup_app()
     fi
 
     pushd "$app" > /dev/null
-    git reset --hard HEAD
+    reset_to_release_branch
     if test "$(type -t setup_"$app_basename")" = "function"; then
         setup_"$app_basename"
     fi


### PR DESCRIPTION
This feature resets all repositories to a release tag. This makes it easier to have a functional setup. Irrespective of updates to different upstream repositories, resetting the local setup to the release tag will provide a stable environment for configuring and building.

There is a `reset` command to each "do.sh" script that will reset application, libraries and Unikraft repositories to a branch created from the release tag. Release tags such as `RELEASE-0.13.1` will result in the creation of a `br-RELEASE-0.13.1` branch in each repository.

The tag is defined in the `include/base` file. Currently, there is no per-release tag configuration file (for each app in the `files/.config` file) ; this is something to be added later.

As of this commit, app configuration files (in `files/.config`) work for the `RELEASE-0.13.1` tag.